### PR TITLE
[sc24705] Updating @single_ops/react-scripts init.js to use with a Ya…

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@single_ops/react-scripts",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "SingleOps Configuration and scripts for Create React App.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Updating @single_ops/react-scripts init.js to use with a Yarn workspace.
It will only run different if the env variable, process.env.WORKSPACE_ROOT_PATH, is present.
Bumping version to 5.0.2, but it really is react-scripts 5.0.1.
